### PR TITLE
#9 Remove BUSD due to discontinue of it's support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cryptoPay.getMe();
 Use this method to create a new invoice. Returns object of created invoice.
 
 * **asset** (string)
-Currency code. Supported assets: `BTC`, `TON`, `ETH`, `USDT`, `USDC` and `BUSD`.
+Currency code. Supported assets: `BTC`, `TON`, `ETH`, `USDT` and `USDC`.
 * **amount** (string)
 Amount of the invoice in float. For example: `125.50`
 * **description** (string)
@@ -162,7 +162,7 @@ Use this method to send coins from your app to the user. Returns object of compl
 * **user_id** (number)
 Telegram User ID. The user needs to have an account in our bot (send /start if no).
 * **asset** (string)
-Currency code. Supported assets: `BTC`, `TON`, `ETH`, `USDT`, `USDC` and `BUSD`.
+Currency code. Supported assets: `BTC`, `TON`, `ETH`, `USDT` and `USDC`.
 * **amount** (string)
 Amount of the transfer in float. The minimum and maximum amounts for each of the support asset roughly correspond to the limit of 1-25000 USD. Use [getExchangeRates](#getExchangeRates) to convert amounts. For example: `125.50`
 * **spend_id** (string)
@@ -181,7 +181,7 @@ cryptoPay.transfer(121011054, Assets.ETH, 0.1, 'ZG9uYXRl', { comment: 'donate' }
 Use this method to get invoices of your app. On success, the returns array of invoices.
 
 * **asset** (string)
-*Optional*. Currency codes separated by comma. Supported assets: `BTC`, `TON`, `ETH`, `USDT`, `USDC` and `BUSD`. Defaults to all assets.
+*Optional*. Currency codes separated by comma. Supported assets: `BTC`, `TON`, `ETH`, `USDT` and `USDC`. Defaults to all assets.
 * **invoice_ids** (string)
 *Optional*. Invoice IDs separated by comma.
 * **status** (string)
@@ -273,7 +273,6 @@ constant      | value
 `Assets.ETH`  | `ETH`
 `Assets.USDT` | `USDT`
 `Assets.USDC` | `USDC`
-`Assets.BUSD` | `BUSD`
 
 ### Paid Button Names
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foile/crypto-pay-api",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Cryptocurrency payment system based on @CryptoBot",
   "license": "MIT",
   "author": "Foile",

--- a/src/crypto-pay.js
+++ b/src/crypto-pay.js
@@ -9,7 +9,6 @@ const Assets = Object.freeze({
   ETH: 'ETH',
   USDT: 'USDT',
   USDC: 'USDC',
-  BUSD: 'BUSD',
 });
 
 const PaidButtonNames = Object.freeze({
@@ -69,7 +68,7 @@ class CryptoPay {
 
   /**
    * Use this method to create a new invoice. Returns object of created invoice
-   * @param {string} asset - Currency code. Supported assets: `BTC`, `TON`, `ETH`, `USDT`, `USDC` and `BUSD`
+   * @param {string} asset - Currency code. Supported assets: `BTC`, `TON`, `ETH`, `USDT` and `USDC`
    * @param {string} amount - Amount of the invoice in float. For example: `125.50`
    * @param {Object} [options]
    * @param {string} [options.description] - Optional. Description for the invoice. User will see this description when they pay the invoice. Up to 1024 characters
@@ -90,7 +89,7 @@ class CryptoPay {
   /**
    * Use this method to send coins from your app to the user. Returns object of completed transfer
    * @param {number} user_id - Telegram User ID
-   * @param {string} asset - Currency code. Supported assets: `BTC`, `TON`, `ETH`, `USDT`, `USDC` and `BUSD`
+   * @param {string} asset - Currency code. Supported assets: `BTC`, `TON`, `ETH`, `USDT` and `USDC`
    * @param {string} amount - Amount of the transfer in float. The minimum and maximum amounts for each of the support asset roughly correspond to the limit of 1-25000 USD. Use getExchangeRates to convert amounts. For example: `125.50`
    * @param {string} spend_id - Uniq ID to make your request idempotent. Up to 64 symbols
    * @param {Object} [options]
@@ -105,7 +104,7 @@ class CryptoPay {
    * Use this method to get invoices of your app. On success, the returns array of invoices
    * @param {Object} [options]
    * @param {string} [options.asset] - Optional. Currency codes separated by comma.
-   * Supported assets: `BTC`, `TON`, `ETH`, `USDT`, `USDC` and `BUSD`. Defaults to all assets
+   * Supported assets: `BTC`, `TON`, `ETH`, `USDT` and `USDC`. Defaults to all assets
    * @param {string} [options.invoice_ids] - Optional. Invoice IDs separated by comma
    * @param {string} [options.status] - Optional. Status of invoices to be returned. Available statuses: `active` and `paid`. Defaults to all statuses
    * @param {number} [options.offset] - Optional. Offset needed to return a specific subset of invoices. Default is 0


### PR DESCRIPTION
Pull Request for Issue #9 due to BUSD Support Deprecation

**Motivation:**
As of version 1.1.5 (dated September 30, 2023), the Crypto Pay API has officially discontinued support for the Binance USD (BUSD) currency. This update is a significant alteration as it directly impacts any clients utilizing BUSD within their transactions.

Given the nature of this change and its potential to disrupt existing client integrations, I have proposed a major version increment for our package. This decision aligns with semantic versioning principles, ensuring that our clients are alerted to the backward-incompatible changes through proper versioning etiquette.

**Key Changes:**

- Deprecation of BUSD support as per Crypto Pay API changes.
- Updated docs.
- Major version bump to reflect breaking changes and promote careful update adoption.